### PR TITLE
Update dependencies to support Laravel 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,9 @@
     "php": "^8.0",
     "ext-json": "*",
     "guzzlehttp/guzzle": "^7.0",
-    "illuminate/contracts": "^8.0 || ^9.0 || ^10.0",
+    "illuminate/contracts": "^8.0 || ^9.0 || ^10.0 || ^11.0",
     "illuminate/http": "^8.0 || ^9.0 || ^10.0",
-    "illuminate/support": "^8.0 || ^9.0 || ^10.0"
+    "illuminate/support": "^8.0 || ^9.0 || ^10.0 || ^11.0"
   },
   "require-dev": {
     "mockery/mockery": "^1.4",

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
   },
   "require-dev": {
     "mockery/mockery": "^1.4",
-    "orchestra/testbench": "^6.0 || ^7.0",
+    "orchestra/testbench": "^6.0 || ^7.0 || ^8.0 || ^9.0",
     "phpunit/phpunit": "^8.5 || ^9.5 || ^10.0",
     "laravel/legacy-factories": "^1.1"
   },

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "first-iraqi-bank/fib-laravel-payment-sdk",
   "description": "Laravel SDK for integrating with the FIB payment system, enabling user authentication and payment transactions.",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "type": "library",
   "keywords": [
     "sdk",
@@ -23,7 +23,7 @@
     "ext-json": "*",
     "guzzlehttp/guzzle": "^7.0",
     "illuminate/contracts": "^8.0 || ^9.0 || ^10.0 || ^11.0",
-    "illuminate/http": "^8.0 || ^9.0 || ^10.0",
+    "illuminate/http": "^8.0 || ^9.0 || ^10.0 || ^11.0",
     "illuminate/support": "^8.0 || ^9.0 || ^10.0 || ^11.0"
   },
   "require-dev": {


### PR DESCRIPTION
### **Summary**
This pull request addresses the compatibility issue with Laravel 11 projects by updating the composer.json file.

### **Changes**
- Updated `composer.json` to support `illuminate/contracts` and `illuminate/support` versions 8.x, 9.x, 10.x, and 11.x.

### **Testing**
- Tested locally with Laravel 11, and the package installs successfully without conflicts.

Please review and approve the changes. Once merged, clients will be able to use this package in Laravel 11 projects.
