### PR TITLE
FIBAS-1671-be-update-fib-laravel-payment-sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ try {
     $this->fibAuthIntegrationService->setAccount('second_account');
      
     // Call the createPayment method of the FIBPaymentIntegrationService
-    $response = $this->paymentService->createPayment(1000, 'http://localhost/callback', 'Your payment description', 'http://localhost/redirectUri');
+    $response = $this->paymentService->createPayment(1000, 'http://localhost/callback', 'Your payment description', 'http://localhost/redirectUri', 'extraData');
 
     $paymentData = json_decode($response->getBody(), true);
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "first-iraqi-bank/fib-laravel-payment-sdk",
   "description": "Laravel SDK for integrating with the FIB payment system, enabling user authentication and payment transactions.",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "type": "library",
   "keywords": [
     "sdk",


### PR DESCRIPTION
Added support for `extraData` in **FIBPaymentIntegrationService** and updated documentation and version to 1.5.1, and added  `redirect_uri`, `extraData`   to the log when the create payment get failed.