### PR TITLE
FIBAS-2163-be-laravel-online-payment-sdk-handle-exception-if-the-client-is-not-authorized

### DIFF
--- a/src/Services/FIBAuthIntegrationService.php
+++ b/src/Services/FIBAuthIntegrationService.php
@@ -5,6 +5,7 @@ namespace FirstIraqiBank\FIBPaymentSDK\Services;
 use Exception;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class FIBAuthIntegrationService
 {
@@ -38,7 +39,6 @@ class FIBAuthIntegrationService
             $response = Http::asForm()
                 ->withoutVerifying()
                 ->withBasicAuth((string) config("fib.auth_accounts.{$this->account}.client_id"), (string) config("fib.auth_accounts.{$this->account}.secret"))
-                ->retry(times: 3, sleepMilliseconds: 100, throw: false)
                 ->post(config('fib.login'), [
                     'grant_type' => config('fib.grant'),
                 ]);
@@ -47,11 +47,6 @@ class FIBAuthIntegrationService
                 return $response->json('access_token');
             }
 
-            Log::error('Fib Payment SDK: Getting token failed', [
-                'status' => $response->status(),
-                'response_body' => $response->body(),
-            ]);
-
         } catch (Exception $e) {
 
             Log::error('Fib Payment SDK: Exception while getting token', ['exception' => $e]);
@@ -59,6 +54,11 @@ class FIBAuthIntegrationService
             throw $e;
         }
 
-        return null;
+        Log::error('Fib Payment SDK: Getting token failed', [
+            'status' => $response->status(),
+            'response_body' => $response->body(),
+        ]);
+
+        throw new HttpException(424, 'Fib Payment SDK: Getting token failed');
     }
 }

--- a/tests/Unit/Services/FIBAuthIntegrationServiceTest.php
+++ b/tests/Unit/Services/FIBAuthIntegrationServiceTest.php
@@ -6,6 +6,7 @@ use Exception;
 use FirstIraqiBank\FIBPaymentSDK\Services\FIBAuthIntegrationService;
 use Illuminate\Support\Facades\Http;
 use Orchestra\Testbench\TestCase;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class FIBAuthIntegrationServiceTest extends TestCase
 {
@@ -38,34 +39,38 @@ class FIBAuthIntegrationServiceTest extends TestCase
         $this->assertEquals('test-token', $token);
     }
 
-    public function test_it_returns_null_when_token_retrieval_fails()
+    public function test_it_throws_exception_when_token_retrieval_fails()
     {
         // Arrange
         Http::fake([
             'https://api.fib.com/login' => Http::response('Error message', 400),
         ]);
 
-        // Act
         $service = new FIBAuthIntegrationService;
 
-        $this->assertNull($service->getToken());
+        // Assert
+        $this->expectException(HttpException::class);
+        $this->expectExceptionMessage('Fib Payment SDK: Getting token failed');
+
+        // Act
+        $service->getToken();
     }
 
-    //        public function test_it_logs_and_throws_exception_on_error()
-    //        {
-    //            // Arrange
-    //            Http::fake(function ($request) {
-    //                throw new Exception('Network Error');
-    //            });
-    //
-    //
-    //            $this->expectException(Exception::class);
-    //            $this->expectExceptionMessage('Network Error');
-    //
-    //            // Act
-    //            $service = new FIBAuthIntegrationService();
-    //            $service->getToken();
-    //        }
+    public function test_it_logs_and_throws_exception_on_error()
+    {
+        // Arrange
+        Http::fake(function ($request) {
+            throw new Exception('Network Error');
+        });
+
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Network Error');
+
+        // Act
+        $service = new FIBAuthIntegrationService();
+        $service->getToken();
+    }
 
     public function test_it_sets_the_account()
     {


### PR DESCRIPTION
Throw exceptions instead of returning null on token retrieval failure in FIBAuthIntegrationService, update logging, and adjust related tests accordingly.